### PR TITLE
Make the system region configurable.

### DIFF
--- a/src/decaf-cli/main.cpp
+++ b/src/decaf-cli/main.cpp
@@ -59,6 +59,12 @@ getCommandLineParser()
       .add_option("sys-path",
                   description { "Where to locate any external system files." },
                   value<std::string> {})
+      .add_option("region",
+                  description { "Set the system region." },
+                  default_value<std::string> { "US" },
+                  allowed<std::string> { {
+                        "EUR", "JAP", "US"
+                  } })
       .add_option("time-scale",
                   description { "Time scale factor for emulated clock." },
                   default_value<double> { 1.0 })
@@ -152,6 +158,19 @@ start(excmd::parser &parser,
 
    if (options.has("sys-path")) {
       decaf::config::system::system_path = options.get<std::string>("sys-path");
+   }
+
+   if (options.has("region")) {
+      const std::string region = options.get<std::string>("region");
+      if (region.compare("JAP") == 0) {
+         decaf::config::system::region = coreinit::SCIRegion::JAP;
+      } else if (region.compare("US") == 0) {
+         decaf::config::system::region = coreinit::SCIRegion::US;
+      } else if (region.compare("EUR") == 0) {
+         decaf::config::system::region = coreinit::SCIRegion::EUR;
+      } else {
+         decaf_abort(fmt::format("Invalid region {}", region));
+      }
    }
 
    if (options.has("time-scale")) {

--- a/src/decaf-sdl/main.cpp
+++ b/src/decaf-sdl/main.cpp
@@ -1,7 +1,9 @@
 #include "clilog.h"
+#include "common/decaf_assert.h"
 #include "config.h"
 #include "decafsdl.h"
 #include "libdecaf/decaf.h"
+#include "libdecaf/src/modules/coreinit/coreinit_enum.h"
 #include <pugixml.hpp>
 #include <excmd.h>
 #include <iostream>
@@ -60,6 +62,12 @@ getCommandLineParser()
       .add_option("sys-path",
                   description { "Where to locate any external system files." },
                   value<std::string> {})
+      .add_option("region",
+                  description { "Set the system region." },
+                  default_value<std::string> { "US" },
+                  allowed<std::string> { {
+                        "EUR", "JAP", "US"
+                  } })
       .add_option("time-scale",
                   description { "Time scale factor for emulated clock." },
                   default_value<double> { 1.0 });
@@ -148,6 +156,19 @@ start(excmd::parser &parser,
 
    if (options.has("sys-path")) {
       decaf::config::system::system_path = options.get<std::string>("sys-path");
+   }
+
+   if (options.has("region")) {
+      const std::string region = options.get<std::string>("region");
+      if (region.compare("JAP") == 0) {
+         decaf::config::system::region = coreinit::SCIRegion::JAP;
+      } else if (region.compare("US") == 0) {
+         decaf::config::system::region = coreinit::SCIRegion::US;
+      } else if (region.compare("EUR") == 0) {
+         decaf::config::system::region = coreinit::SCIRegion::EUR;
+      } else {
+         decaf_abort(fmt::format("Invalid region {}", region));
+      }
    }
 
    if (options.has("time-scale")) {

--- a/src/libdecaf/decaf_config.h
+++ b/src/libdecaf/decaf_config.h
@@ -61,6 +61,9 @@ namespace system
 //! Path to system files
 extern std::string system_path;
 
+//! Emulated system region
+extern int region;
+
 //! Time scale factor for emulated clock
 extern double time_scale;
 

--- a/src/libdecaf/src/decaf_config.cpp
+++ b/src/libdecaf/src/decaf_config.cpp
@@ -1,4 +1,5 @@
 #include "decaf_config.h"
+#include "modules/coreinit/coreinit_enum.h"
 
 namespace decaf
 {
@@ -55,6 +56,7 @@ namespace system
 {
 
 std::string system_path = "/undefined_system_path";
+int region = static_cast<int>(coreinit::SCIRegion::US);
 double time_scale = 1.0;
 
 } // namespace system

--- a/src/libdecaf/src/modules/coreinit/coreinit_enum.h
+++ b/src/libdecaf/src/modules/coreinit/coreinit_enum.h
@@ -284,6 +284,7 @@ ENUM_BEG(SCILanguage, uint32_t)
 ENUM_END(SCILanguage)
 
 ENUM_BEG(SCIRegion, uint8_t)
+   ENUM_VALUE(JAP,                  0x01)
    ENUM_VALUE(US,                   0x02)
    ENUM_VALUE(EUR,                  0x04)
 ENUM_END(SCIRegion)

--- a/src/libdecaf/src/modules/coreinit/coreinit_mcp.cpp
+++ b/src/libdecaf/src/modules/coreinit/coreinit_mcp.cpp
@@ -1,6 +1,7 @@
 #include "coreinit.h"
 #include "coreinit_mcp.h"
 #include "common/decaf_assert.h"
+#include "decaf_config.h"
 
 namespace coreinit
 {
@@ -28,8 +29,8 @@ MCP_GetSysProdSettings(IOHandle handle, MCPSysProdSettings *settings)
    }
 
    memset(settings, 0, sizeof(MCPSysProdSettings));
-   settings->gameRegion = SCIRegion::US;
-   settings->platformRegion = SCIRegion::US;
+   settings->gameRegion = static_cast<SCIRegion>(decaf::config::system::region);
+   settings->platformRegion = static_cast<SCIRegion>(decaf::config::system::region);
    return IOError::OK;
 }
 


### PR DESCRIPTION
Not sure how you feel about #including coreinit_enum.h at higher levels just to get the region enums. Another possibility would be to just store it as a string and make the conversion within coreinit::MCP_GetSysProdSettings(), which is a bit slower but I can't imagine that function is a hotspot.

Diffed against the time-scale branch just because the command line option diffs are adjacent.
